### PR TITLE
put file path after flags

### DIFF
--- a/denoget.ts
+++ b/denoget.ts
@@ -168,8 +168,8 @@ async function main() {
   }
   const commands = [
     'deno',
-    SRC_FILE_PATH,
     ...grantedPermissions.map(getFlagFromPermission),
+    SRC_FILE_PATH,
     '$@',
   ];
 


### PR DESCRIPTION
I noticed that permissions were not working after the latest arg parsing changes
to deno. Moving the script name to after the permission flags fixes that.

In other words, it seems that when executed this way, flags are not properly passed to the script:
```
deno /path/to/script.ts --allow-write --allow-read --allow-run $@
```

But switching the flags to before the script name fixes the issue:
```
deno --allow-write --allow-read --allow-run /path/to/script.ts $@
```

